### PR TITLE
Update social-share.html

### DIFF
--- a/layouts/partials/social-share.html
+++ b/layouts/partials/social-share.html
@@ -3,7 +3,7 @@
 
 {{ $facebook_href := printf "https://www.facebook.com/sharer.php?u=%s" $url }}
 {{ $twitter_href := printf "https://twitter.com/intent/tweet?url=%s&text=%s" $url $title }}
-{{ with site.Social.twitter }}
+{{ with site.Params.Social.twitter }}
   {{ $twitter_href = printf "%s&via=%s" $twitter_href . }}
 {{ end }}
 {{ $linkedin_href := printf "https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s" $url $title }}


### PR DESCRIPTION
FIX: ERROR deprecated: .Site.Social was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.137.0. Implement taxonomy 'social' or use .Site.Params.Social instead.

Closes #711